### PR TITLE
Fix null pointer crash when style.label.fontColor is null.

### DIFF
--- a/src/main/java/com/github/tommyettinger/textra/TextraTooltip.java
+++ b/src/main/java/com/github/tommyettinger/textra/TextraTooltip.java
@@ -108,7 +108,7 @@ public class TextraTooltip extends Tooltip<TextraLabel> {
 		if (style == null) throw new NullPointerException("style cannot be null");
 		Container<TextraLabel> container = getContainer();
 		container.getActor().font = new Font(style.label.font, Font.DistanceFieldType.STANDARD, 0, 0, 0, 0, makeGridGlyphs);
-		container.getActor().setColor(style.label.fontColor);
+		if (style.label.fontColor != null) container.getActor().setColor(style.label.fontColor);
 		container.getActor().layout.targetWidth = style.wrapWidth;
 		container.getActor().font.calculateSize(container.getActor().layout);
 		container.getActor().setWidth(container.getActor().layout.getWidth());
@@ -121,7 +121,7 @@ public class TextraTooltip extends Tooltip<TextraLabel> {
 		Container<TextraLabel> container = getContainer();
 		container.getActor().font = font;
 		container.getActor().layout.targetWidth = style.wrapWidth;
-		container.getActor().setColor(style.label.fontColor);
+		if (style.label.fontColor != null) container.getActor().setColor(style.label.fontColor);
 		font.calculateSize(container.getActor().layout);
 		container.getActor().setWidth(container.getActor().layout.getWidth());
 		container.setBackground(style.background);


### PR DESCRIPTION
LabelStyle#fontColor is an optional field and can be expected to be null. This causes a crash in TextraTooltip which would otherwise be ignored in TextTooltip.