### PR TITLE
Added FontFamily constructor that takes a Skin as a parameter.

### DIFF
--- a/src/main/java/com/github/tommyettinger/textra/Font.java
+++ b/src/main/java/com/github/tommyettinger/textra/Font.java
@@ -24,6 +24,7 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.*;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.CharArray;
@@ -35,6 +36,7 @@ import com.badlogic.gdx.utils.JsonValue;
 import com.badlogic.gdx.utils.LongArray;
 import com.badlogic.gdx.utils.NumberUtils;
 import com.badlogic.gdx.utils.ObjectIntMap;
+import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.OrderedMap;
 import com.badlogic.gdx.utils.Pool;
 import com.github.tommyettinger.textra.utils.BlockUtils;
@@ -305,6 +307,21 @@ public class Font implements Disposable {
             for (int i = 0; i < map.size && i < 16; i++) {
                 String name = ks.get(i);
                 if ((connected[i] = map.get(name)) == null) continue;
+                fontAliases.put(name, i);
+                fontAliases.put(connected[i].name, i);
+                fontAliases.put(String.valueOf(i), i);
+            }
+        }
+        
+        public FontFamily(Skin skin) {
+            ObjectMap<String, BitmapFont> map = skin.getAll(BitmapFont.class);
+            Array<String> keys = map.keys().toArray();
+            for (int i = 0; i < map.size && i < 16; i++) {
+                String name = keys.get(i);
+                Font font = new Font(map.get(name));
+                font.name = name;
+                font.family = this;
+                connected[i] = font;
                 fontAliases.put(name, i);
                 fontAliases.put(connected[i].name, i);
                 fontAliases.put(String.valueOf(i), i);

--- a/src/test/java/com/github/tommyettinger/textra/FontFamilySkinTest.java
+++ b/src/test/java/com/github/tommyettinger/textra/FontFamilySkinTest.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright 2021 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.github.tommyettinger.textra;
+
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import com.github.tommyettinger.textra.Font.FontFamily;
+
+public class FontFamilySkinTest extends InputAdapter implements ApplicationListener {
+	Skin skin;
+	Stage stage;
+
+	@Override
+	public void create () {
+		skin = new Skin(Gdx.files.internal("shadeui/uiskin.json"));
+		final FontFamily family = new FontFamily(skin);
+		
+		stage = new Stage(new ScreenViewport());
+		Gdx.input.setInputProcessor(stage);
+
+		Table root = new Table();
+		root.setFillParent(true);
+		stage.addActor(root);
+		
+		TextraLabel textraLabel = new TextraLabel("Default-font, [@font-button]font-button, [@font-label]font-label, [@font-title]font-title", family.connected[0]);
+		root.add(textraLabel);
+		
+		for (String name : family.fontAliases.keys()) {
+			System.out.println("name = " + name);
+		}
+	}
+
+	@Override
+	public void render () {
+		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		stage.draw();
+	}
+
+	@Override
+	public void pause() {
+
+	}
+
+	@Override
+	public void resume() {
+
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		stage.getViewport().update(width, height, true);
+	}
+
+	@Override
+	public void dispose () {
+		stage.dispose();
+		skin.dispose();
+	}
+
+	public static void main(String[] args){
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		config.setTitle("FontFamilySkin test");
+		config.setWindowedMode(640, 540);
+		config.disableAudio(true);
+		config.useVsync(true);
+		config.setForegroundFPS(0);
+		new Lwjgl3Application(new FontFamilySkinTest(), config);
+	}
+
+}


### PR DESCRIPTION
This PR enables creating a FontFamily from a Scene2D.UI Skin. This is a convenience method to expedite the use of font switching as the names of fonts in a Skin are already known.